### PR TITLE
Sync with compute-image-tools/daisy

### DIFF
--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -73,7 +73,7 @@ func TestAddFlags(t *testing.T) {
 }
 
 func TestParseWorkflows(t *testing.T) {
-	path := "../../daisy/test_data/test.wf.json"
+	path := "../test_data/test.wf.json"
 	varMap := map[string]string{"key1": "var1", "key2": "var2"}
 	project := "project"
 	zone := "zone"

--- a/disk_test.go
+++ b/disk_test.go
@@ -34,7 +34,7 @@ func TestDiskPopulate(t *testing.T) {
 	genName := w.genName(name)
 	defType := fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-standard", w.Project, w.Zone)
 	ssdType := fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-ssd", w.Project, w.Zone)
-	tests := []struct {git remote add origin git@github.com:GoogleCloudPlatform/compute-daisy.git
+	tests := []struct {
 		desc        string
 		input, want *Disk
 		wantErr     bool


### PR DESCRIPTION
This PR includes four individual commits that achieve the following (I'd recommend *not* squashing when merging in)

1. Ensure that `go test ./...` passes
2. Port the two commits that are in compute-image-tools/daisy, but are not here: https://github.com/GoogleCloudPlatform/compute-image-tools/commits/master/daisy
3. Re-add workflow-modification functions (and mark them deprecated)

## Testing
- Ran `go test ./...`
- Ran `gcr.io/gcp-guest/gocheck`