### PR TITLE
Fix template for e2e tests

### DIFF
--- a/daisy_integration_tests/daisy_e2e.test.gotmpl
+++ b/daisy_integration_tests/daisy_e2e.test.gotmpl
@@ -1,5 +1,5 @@
 {
-  "Name": "daisy-e2e-tests",
+  "Name": "compute-daisy-e2e",
   "TestParallelCount": 30,
   "Tests": {
     "Sources upload/download": {
@@ -26,7 +26,7 @@
     "Step CreateNetworks": {
       "Path": "./step_create_networks.wf.json"
     },
-    "Step CreateNetworks": {
+    "Step CreateSnapshots": {
       "Path": "./step_create_snapshots.wf.json"
     },
     "Step DetachDisks": {
@@ -40,6 +40,6 @@
     },
     "Validate cloud logging": {
       "Path": "./validate_cloud_logging.wf.json"
-    },
+    }
   }
 }


### PR DESCRIPTION
Fixed the `gotmpl` so that it's runnable with daisy_test_runner.

Here are the results of running the prowjob locally: https://oss-prow.knative.dev/view/gs/compute-image-tools-test/logs/compute-daisy-e2e/1491518285269700608