### PR TITLE
Wait For Instance: make it backward compatible & migrate tests

### DIFF
--- a/step_wait_for_instances_signal.go
+++ b/step_wait_for_instances_signal.go
@@ -27,9 +27,7 @@ import (
 )
 
 const (
-	defaultInterval           = "10s"
-	defaultGuestAttrNamespace = "daisy"
-	defaultGuestAttrKeyName   = "DaisyResult"
+	defaultInterval = "10s"
 )
 
 var (
@@ -210,9 +208,13 @@ func waitForSerialOutput(s *Step, project, zone, name string, so *SerialOutput, 
 }
 
 func waitForGuestAttribute(s *Step, project, zone, name string, ga *GuestAttribute, interval time.Duration) DError {
-	ga.KeyName = strOr(ga.KeyName, defaultGuestAttrKeyName)
-	ga.Namespace = strOr(ga.Namespace, defaultGuestAttrNamespace)
-	varkey := fmt.Sprintf("%s/%s", ga.Namespace, ga.KeyName)
+	var keyTokens []string
+	if ga.Namespace != "" {
+		keyTokens = append(keyTokens, ga.Namespace)
+	}
+	keyTokens = append(keyTokens, ga.KeyName)
+	varkey := strings.Join(keyTokens, "/")
+
 	w := s.w
 	msg := fmt.Sprintf("Instance %q: watching for key %s", name, varkey)
 	if ga.SuccessValue != "" {

--- a/step_wait_for_instances_signal_test.go
+++ b/step_wait_for_instances_signal_test.go
@@ -158,7 +158,9 @@ func testWaitForSignalRun(t *testing.T, waitAny bool) {
 		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", FailureMatch: []string{"fail"}}},
 		{Name: "i1", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{SuccessMatch: "success", FailureMatch: []string{"fail", "fail2"}}},
 		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey"}},
+		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{Namespace: "mynamespace", KeyName: "mykey"}},
 		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey", SuccessValue: "success"}},
+		{Name: "i1", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{Namespace: "mynamespace", KeyName: "mykey", SuccessValue: "success"}},
 		{Name: "i3", interval: 1 * time.Microsecond, Stopped: true},
 	})
 	if err := ws.run(ctx, s); err != nil {
@@ -169,6 +171,7 @@ func testWaitForSignalRun(t *testing.T, waitAny bool) {
 		{Name: "i2", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{FailureMatch: []string{"fail"}, SuccessMatch: "success"}},
 		{Name: "i3", interval: 1 * time.Microsecond, SerialOutput: &SerialOutput{FailureMatch: []string{"fail"}}},
 		{Name: "i2", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{KeyName: "mynamespace/mykey", SuccessValue: "success"}},
+		{Name: "i2", interval: 1 * time.Microsecond, GuestAttribute: &GuestAttribute{Namespace: "mynamespace", KeyName: "mykey", SuccessValue: "success"}},
 	})
 	if err := ws.run(ctx, s); err == nil {
 		t.Error("expected error")


### PR DESCRIPTION
With the introduction of the Namespace field for GuestAttribute the configurations without the field namely those with namespace and key composed in the KeyName field (i.e namespace/key) would be broken.

This patch changes the implementation to not assume Namespace is always present and introduce tests using the newly added Namespace field.