### PR TITLE
Allow overriding CloudLogging Client object in Daisy workflow

### DIFF
--- a/disk_test.go
+++ b/disk_test.go
@@ -279,7 +279,7 @@ func TestDiskRegDetachAll(t *testing.T) {
 	// - error from helper
 	// - skip already detached
 	w := testWorkflow()
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	s, _ := w.NewStep("s")
 	otherDetacher, _ := w.NewStep("other-detacher")
 

--- a/logger.go
+++ b/logger.go
@@ -65,18 +65,18 @@ func (w *Workflow) createLogger(ctx context.Context) {
 		periodicFlush(func() { l.gcsLogWriter.Flush() })
 	}
 
-	if !w.cloudLoggingDisabled && w.cloudLoggingClient != nil {
+	if !w.cloudLoggingDisabled && w.CloudLoggingClient != nil {
 		// Verify we can communicate with the log service.
-		if err := w.cloudLoggingClient.Ping(ctx); err != nil {
+		if err := w.CloudLoggingClient.Ping(ctx); err != nil {
 			l.WriteLogEntry(&LogEntry{
 				LocalTimestamp: time.Now(),
 				WorkflowName:   getAbsoluteName(w),
 				Message:        fmt.Sprintf("Unable to send logs to the Cloud Logging service, not sending logs: %v", err),
 			})
-			w.cloudLoggingClient = nil
+			w.CloudLoggingClient = nil
 		} else {
 			cloudLogName := fmt.Sprintf("daisy-%s-%s", w.Name, w.id)
-			l.cloudLogger = w.cloudLoggingClient.Logger(cloudLogName)
+			l.cloudLogger = w.CloudLoggingClient.Logger(cloudLogName)
 			periodicFlush(func() { l.cloudLogger.Flush() })
 		}
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -225,7 +225,7 @@ func TestNetworkRegDisconnectAll(t *testing.T) {
 	// - error from helper
 	// - skip already disconnected
 	w := testWorkflow()
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	s, _ := w.NewStep("s")
 	otherDisconnector, _ := w.NewStep("other-disconnector")
 

--- a/step_delete_resources_test.go
+++ b/step_delete_resources_test.go
@@ -155,7 +155,7 @@ func TestDeleteResourcesValidate(t *testing.T) {
 	ctx := context.Background()
 	// Set up.
 	w := testWorkflow()
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	dC, _ := w.NewStep("dCreator")
 	imC, _ := w.NewStep("imCreator")
 	miC, _ := w.NewStep("miCreator")

--- a/step_includeworkflow.go
+++ b/step_includeworkflow.go
@@ -51,7 +51,7 @@ func (i *IncludeWorkflow) populate(ctx context.Context, s *Step) DError {
 	i.Workflow.username = i.Workflow.parent.username
 	i.Workflow.ComputeClient = i.Workflow.parent.ComputeClient
 	i.Workflow.StorageClient = i.Workflow.parent.StorageClient
-	i.Workflow.cloudLoggingClient = i.Workflow.parent.cloudLoggingClient
+	i.Workflow.CloudLoggingClient = i.Workflow.parent.CloudLoggingClient
 	i.Workflow.GCSPath = i.Workflow.parent.GCSPath
 	i.Workflow.Name = i.Workflow.parent.Name
 	i.Workflow.Project = i.Workflow.parent.Project

--- a/step_includeworkflow_test.go
+++ b/step_includeworkflow_test.go
@@ -44,7 +44,7 @@ func TestIncludeWorkflowPopulate(t *testing.T) {
 			},
 		},
 	}
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	s := &Step{
 		name: "step-name",
 		w:    w,

--- a/subnetwork_test.go
+++ b/subnetwork_test.go
@@ -220,7 +220,7 @@ func TestSubnetworkRegDisconnectAll(t *testing.T) {
 	// - error from helper
 	// - skip already disconnected
 	w := testWorkflow()
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	s, _ := w.NewStep("s")
 	otherDisconnector, _ := w.NewStep("other-disconnector")
 

--- a/test_common_test.go
+++ b/test_common_test.go
@@ -112,7 +112,7 @@ func testWorkflow() *Workflow {
 	w.Zone = testZone
 	w.ComputeClient, _ = newTestGCEClient()
 	w.StorageClient, _ = newTestGCSClient()
-	w.cloudLoggingClient, _ = newTestLoggingClient()
+	w.CloudLoggingClient, _ = newTestLoggingClient()
 	w.Cancel = make(chan struct{})
 	w.Logger = &MockLogger{}
 	return w

--- a/workflow.go
+++ b/workflow.go
@@ -142,7 +142,7 @@ type Workflow struct {
 	ComputeEndpoint    string          `json:",omitempty"`
 	ComputeClient      compute.Client  `json:"-"`
 	StorageClient      *storage.Client `json:"-"`
-	cloudLoggingClient *logging.Client
+	CloudLoggingClient *logging.Client `json:"-"`
 
 	// Resource registries.
 	disks           *diskRegistry
@@ -416,8 +416,8 @@ func (w *Workflow) PopulateClients(ctx context.Context, options ...option.Client
 		}
 	}
 
-	if w.externalLogging && !w.cloudLoggingDisabled && w.cloudLoggingClient == nil {
-		w.cloudLoggingClient, err = logging.NewClient(ctx, w.Project, loggingOptions...)
+	if w.externalLogging && !w.cloudLoggingDisabled && w.CloudLoggingClient == nil {
+		w.CloudLoggingClient, err = logging.NewClient(ctx, w.Project, loggingOptions...)
 		if err != nil {
 			return err
 		}

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -679,7 +679,7 @@ func TestPopulate(t *testing.T) {
 	want.Cancel = got.Cancel
 	want.cleanupHooks = got.cleanupHooks
 	want.StorageClient = got.StorageClient
-	want.cloudLoggingClient = got.cloudLoggingClient
+	want.CloudLoggingClient = got.CloudLoggingClient
 	want.Logger = got.Logger
 	want.disks = newDiskRegistry(want)
 	want.images = newImageRegistry(want)
@@ -1122,30 +1122,30 @@ func TestPopulateClients(t *testing.T) {
 		t.Errorf("Did not populate storage client.")
 	}
 
-	initialCloudLoggingClient := w.cloudLoggingClient
+	initialCloudLoggingClient := w.CloudLoggingClient
 	tryPopulateClients(t, w)
-	if w.cloudLoggingClient != initialCloudLoggingClient {
+	if w.CloudLoggingClient != initialCloudLoggingClient {
 		t.Errorf("Should not repopulate logging client.")
 	}
 
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	w.externalLogging = false
 	tryPopulateClients(t, w)
-	if w.cloudLoggingClient != nil {
+	if w.CloudLoggingClient != nil {
 		t.Errorf("Should not populate Cloud Logging client.")
 	}
 
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	w.externalLogging = true
 	tryPopulateClients(t, w)
-	if w.cloudLoggingClient == nil {
+	if w.CloudLoggingClient == nil {
 		t.Errorf("Did not populate Cloud Logging client.")
 	}
 
-	w.cloudLoggingClient = nil
+	w.CloudLoggingClient = nil
 	w.DisableCloudLogging()
 	tryPopulateClients(t, w)
-	if w.cloudLoggingClient != nil {
+	if w.CloudLoggingClient != nil {
 		t.Errorf("Cloud Logging client populated when Cloud Logging is disabled.")
 	}
 


### PR DESCRIPTION
Compute & Storage Client objects are already overridable in Daisy Workflow. 
Adding this change will allow Daisy users to use custom cloud-logging clients with their custom APIs Endpoints.

/assign @adjackura

/cc @adjackura
/cc @bkatyl
/cc @zmarano