### PR TITLE
Respect subnet region when the user specifies one

### DIFF
--- a/subnetwork.go
+++ b/subnetwork.go
@@ -53,7 +53,11 @@ func (sn *Subnetwork) populate(ctx context.Context, s *Step) DError {
 	sn.Name, errs = sn.Resource.populateWithGlobal(ctx, s, sn.Name)
 
 	sn.Description = strOr(sn.Description, defaultDescription("Subnetwork", s.w.Name, s.w.username))
-	sn.link = fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", sn.Project, getRegionFromZone(s.w.Zone), sn.Name)
+	r := sn.Region
+	if r == "" {
+		r = getRegionFromZone(s.w.Zone)
+	}
+	sn.link = fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", sn.Project, r, sn.Name)
 	return errs
 }
 


### PR DESCRIPTION
Root cause of some problems we're having in CIT, causing test execution failures here: https://testgrid.k8s.io/googleoss-gcp-guest#cit-periodics-performance

daisy does not respect user-specified regions in create subnetwork steps.