### PR TITLE
`CreateInstance`: Recognize `Scheduling.MaxDuration` as a beta feature.

### DIFF
--- a/step_create_instances.go
+++ b/step_create_instances.go
@@ -232,7 +232,13 @@ func (ci *CreateInstances) run(ctx context.Context, s *Step) DError {
 
 func (ci *CreateInstances) instanceUsesBetaFeatures() bool {
 	for _, instanceBeta := range ci.InstancesBeta {
-		if instanceBeta != nil && instanceBeta.SourceMachineImage != "" {
+		if instanceBeta == nil {
+			continue
+		}
+		if instanceBeta.SourceMachineImage != "" {
+			return true
+		}
+		if instanceBeta.Scheduling != nil && instanceBeta.Scheduling.MaxRunDuration != nil {
 			return true
 		}
 	}


### PR DESCRIPTION
`CreateInstance`: Recognize `Scheduling.MaxDuration` as a beta feature.

The `Scheduling.MaxRunDuration` feature of GCE VMs causes them to self-destruct after a given duration. This is convenient to use in Daisy workflows in order to automatically clean up VMs created by workflows that are interrupted for whatever reason.

This feature is only enabled as a beta GCE feature. From my reading of the Daisy code, `CreateInstances.instanceUsesBetaFeatures` must return `true` for Daisy to actually use the `beta` variant of the `compute.Instance` struct in its API call to create a VM instance.

This change augments `CreateInstances.instanceUsesBetaFeatures` to look for the `Scheduling.MaxRunDuration` feature feature, and returns `true` if the instance uses it.